### PR TITLE
Alter feeds query for greater efficacy+efficiency.

### DIFF
--- a/page-feedlist.php
+++ b/page-feedlist.php
@@ -23,7 +23,7 @@ if ( $query->have_posts() ) : ?>
 	<?php while ( $query->have_posts() ) : $query->the_post(); ?>	
 		<div class="entry">
 			<?php 
-				echo '<a href="' . get_the_guid() . '">'; 
+				echo '<a href="' . get_post_meta(get_the_ID(), 'feedUrl', true) . '">'; 
 				the_title(); 
 				echo '</a>'; 
 			?>

--- a/page-feedlist.php
+++ b/page-feedlist.php
@@ -17,14 +17,13 @@ Template Name: PressForward Feed List
 
 
 <?php
-$query = new WP_Query( array( 'post_type' => 'pf_feed' ) );
+$query = new WP_Query( array( 'post_type' => pressforward()->pf_feeds->post_type, 'nopaging' => true ) );
 				
-
 if ( $query->have_posts() ) : ?>
 	<?php while ( $query->have_posts() ) : $query->the_post(); ?>	
 		<div class="entry">
 			
-			<?php echo '<a href="' . $post->feedUrl . '">' ?><?php echo the_title() . '</a>' ?>
+			<?php echo '<a href="' . get_the_guid() . '">' ?><?php echo the_title() . '</a>' ?>
 		</div>
 	<?php endwhile; wp_reset_postdata(); ?>
 <?php endif; ?>

--- a/page-feedlist.php
+++ b/page-feedlist.php
@@ -22,8 +22,11 @@ $query = new WP_Query( array( 'post_type' => pressforward()->pf_feeds->post_type
 if ( $query->have_posts() ) : ?>
 	<?php while ( $query->have_posts() ) : $query->the_post(); ?>	
 		<div class="entry">
-			
-			<?php echo '<a href="' . get_the_guid() . '">' ?><?php echo the_title() . '</a>' ?>
+			<?php 
+				echo '<a href="' . get_the_guid() . '">'; 
+				the_title(); 
+				echo '</a>'; 
+			?>
 		</div>
 	<?php endwhile; wp_reset_postdata(); ?>
 <?php endif; ?>


### PR DESCRIPTION
You can't use $post that way, unless you declare it as an object WordPress doesn't give it scope inside The Loop. That is an empty object. 

Also feedUrl isn't an aspect of the object, we couldn't set it and it can't be accessed that way even if we did declare that as a piece of post_meta.

We store the URL of each feed in the GUID aspect though, so it is directly accessible from the post object and because it is a unique identifier. 

With this in mind, you can use the standard functions to access that property in the loop. And as long as PressForward is on, the post_type variable should be accessible via this method.

By switching to nopaging, you'll also get the full list of feeds, which is the way I assume you want to go?